### PR TITLE
Fix broken link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -117,5 +117,5 @@ Contributions welcomed! Read the [contribution guidelines](contributing.md) firs
 
 [![CC0](https://mirrors.creativecommons.org/presskit/buttons/88x31/svg/cc-zero.svg)](https://creativecommons.org/publicdomain/zero/1.0)
 
-To the extent possible under law, [se-ml.github.io](se-ml.github.io) has waived all copyright and
+To the extent possible under law, [se-ml.github.io](https://se-ml.github.io/) has waived all copyright and
 related or neighboring rights to this work.


### PR DESCRIPTION
The current link goes to https://github.com/SE-ML/awesome-seml/blob/master/se-ml.github.io
This patch just fixes it.