### PR TITLE
Fix link in contents section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ Feel free to [take and share the survey!](https://se-ml.github.io/survey/)
 
 - [Broad Overviews](#broad-overviews)
 - [Data Management](#data-management)
-- [Managing Model Training](#managing-model-training)
+- [Model Training](#model-training)
 - [Deployment and Operation](#deployment-and-operation)
 - [Social aspects](#social-aspects)
 - [Tooling](#tooling)


### PR DESCRIPTION
The link to the model training section did not work. I also updated the text of the link to match the title of the section.